### PR TITLE
fix: deploy issue

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+  provider   = "prisma-client-js"
+  engineType = "client"
 }
 
 datasource db {


### PR DESCRIPTION
fix "This is likely caused by tooling that has not copied "libquery_engine-rhel-openssl-3.0.x.so.node" to the deployment folder." error