### PR TITLE
fix: deploy

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,10 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  outputFileTracingIncludes: {
+    '/api/**/*': ['./node_modules/.prisma/client/**/*'],
+    '/*': ['./node_modules/.prisma/client/**/*'],
+  },
 };
 
 export default nextConfig;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider   = "prisma-client-js"
-  engineType = "client"
+  binaryTargets = ["native", "rhel-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
error: Prisma Client could not locate the Query Engine for runtime "rhel-openssl-3.0.x